### PR TITLE
Fix a bug of "[FIX] Skip header row when not a DDL query"

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -51,7 +51,7 @@ func (c *conn) runQuery(ctx context.Context, query string) (driver.Rows, error) 
 	return newRows(rowsConfig{
 		Athena:     c.athena,
 		QueryID:    queryID,
-		SkipHeader: isDDLQuery(query),
+		SkipHeader: !isDDLQuery(query),
 	})
 }
 


### PR DESCRIPTION
Fixed an error that rows are not returned.
The program skipped header row when DDL query.

https://github.com/segmentio/go-athena/pull/10