### PR TITLE
[FIX] Header not skipped if the result contains no rows

### DIFF
--- a/rows_api.go
+++ b/rows_api.go
@@ -2,10 +2,11 @@ package athena
 
 import (
 	"database/sql/driver"
+	"io"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/athena"
 	"github.com/aws/aws-sdk-go/service/athena/athenaiface"
-	"io"
 )
 
 type rowsAPI struct {
@@ -67,6 +68,10 @@ func (r *rowsAPI) fetchNextPage(token *string) (bool, error) {
 }
 
 func (r *rowsAPI) nextAPI(dest []driver.Value) error {
+	if r.done {
+		return io.EOF
+	}
+
 	// If nothing left to iterate...
 	if len(r.out.ResultSet.Rows) == 0 {
 		// And if nothing more to paginate...


### PR DESCRIPTION
## What

In 139da8c43255db36066cf9d705dff237afaa41bc, `r.done` check in `Next()` has been omitted and causes the bug.

## Why

bugfix

## How

Add the check and test.

## Ref
