### PR TITLE
Getting output location from workgroup and fixing bug in GZIP DL Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ The tests support a few environment variables:
 - `ATHENA_DATABASE` can be used to override the default database "go_athena_tests"
 - `S3_BUCKET` can be used to override the default S3 bucket of "go-athena-tests"
 - `ATHENA_REGION` or `AWS_DEFAULT_REGION` can be used to override the default region of "us-east-1"
+- `ATHENA_WORK_GROUP` can be used to override the default workgroup of "primary"
+- `ATHENA_AUTO_OUTPUT_LOCATION` is a parameter for test of getting output_location value from workgroup
+  - 0 (default value): Useless
+  - 1: It can make you get output_location value from query result location in workgroup
 
 
 [database/sql]: https://golang.org/pkg/database/sql/

--- a/README.md
+++ b/README.md
@@ -73,9 +73,6 @@ The tests support a few environment variables:
 - `S3_BUCKET` can be used to override the default S3 bucket of "go-athena-tests"
 - `ATHENA_REGION` or `AWS_DEFAULT_REGION` can be used to override the default region of "us-east-1"
 - `ATHENA_WORK_GROUP` can be used to override the default workgroup of "primary"
-- `ATHENA_AUTO_OUTPUT_LOCATION` is a parameter for test of getting output_location value from workgroup
-  - 0 (default value): Useless
-  - 1: It can make you get output_location value from query result location in workgroup
 
 
 [database/sql]: https://golang.org/pkg/database/sql/

--- a/conn.go
+++ b/conn.go
@@ -72,6 +72,15 @@ func (c *conn) runQuery(ctx context.Context, query string) (driver.Rows, error) 
 		catalog = cat
 	}
 
+	// output location (with empty value)
+	if checkOutputLocation(resultMode, c.OutputLocation) {
+		var err error
+		c.OutputLocation, err = getOutputLocation(c.athena, c.workgroup)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	// mode ctas
 	var ctasTable string
 	var afterDownload func() error

--- a/rows_gzip.go
+++ b/rows_gzip.go
@@ -94,6 +94,10 @@ func (r *rowsGzipDL) downloadCompressedDataAsync(
 }
 
 func (r *rowsGzipDL) downloadCompressedData(sess *session.Session, location string) error {
+	if location[len(location)-1:] == "/" {
+		location = location[:len(location)-1]
+	}
+
 	// remove the first 5 characters "s3://" from location
 	bucketName := location[5:]
 


### PR DESCRIPTION
## What

- [ISSUE]Getting output_location from workgroup
- [FIX]Fixing the error which occurs when the last character of output_location is '/' in `GZIP DL` Mode

## Why

- making workgroup available in DL / GZIP DL mode
  - resolution [this issue](https://github.com/speee/go-athena/issues/15)
- bugfix

## How

### [ISSUE]Getting output_location from workgroup

Use [get-work-group](https://awscli.amazonaws.com/v2/documentation/api/latest/reference/athena/get-work-group.html) API to get the value of output_location from workgroup

- conditions
    1. The output_location value is empty
    1. Result Mode is either DL Mode or GZIP DL Mode
    1. When sql.Open method is executed or when the query is executed
        - [In Open method](https://github.com/speee/go-athena/pull/18/files#diff-d16a4232641fc7ed88a3737c22b4f54d7e03dd7fdf9053530fde70e5bca63fb1R93)
        - [In execution query processing](https://github.com/speee/go-athena/pull/18/files#diff-4f427d2b022907c552328e63f137561f6de92396d7a6e8f6c2ea1bcf0db52654R76)

### [FIX]Fixing the error which occurs when the last character of output_location is '/' in `GZIP DL` Mode
- [update this code](https://github.com/speee/go-athena/pull/18/files#diff-cc666ac4061074dff2388500f9c5e0acd11851f9be513de1a92536c3fef28ac1R97)

## Ref

- https://github.com/speee/go-athena/issues/15
