### PR TITLE
upgrade go version in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.gitignore
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.14
+FROM golang:1.23
 
 WORKDIR /go/src/github.com/speee/go-athena
 


### PR DESCRIPTION
## What
Upgrade the go version in the Dockerfile.

## Why
To confirm that it works with go1.23.

## How
Confirmed that it builds, runs, and tests with go1.23.

```
$ docker run -e AWS_SECRET_ACCESS_KEY -e AWS_ACCESS_KEY_ID -e AWS_ACCOUNT_ID -e S3_BUCKET <DOCKER_IMAGE_NAME> go test ./... -v
go: downloading github.com/aws/aws-sdk-go v1.40.58
go: downloading github.com/prestodb/presto-go-client v0.0.0-20201204133205-8958eb37e584
go: downloading github.com/satori/go.uuid v1.2.0
go: downloading github.com/stretchr/testify v1.7.0
go: downloading gopkg.in/jcmturner/gokrb5.v6 v6.1.1
go: downloading github.com/davecgh/go-spew v1.1.1
go: downloading github.com/pmezard/go-difflib v1.0.0
go: downloading gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
go: downloading github.com/jmespath/go-jmespath v0.4.0
go: downloading golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d
go: downloading github.com/jcmturner/gofork v1.0.0
go: downloading gopkg.in/jcmturner/dnsutils.v1 v1.0.1
go: downloading gopkg.in/jcmturner/aescts.v1 v1.0.1
go: downloading github.com/hashicorp/go-uuid v1.0.2
go: downloading gopkg.in/jcmturner/rpc.v1 v1.1.0
=== RUN   Test_getCatalog
=== RUN   Test_getCatalog/Default
=== RUN   Test_getCatalog/SetCatalog
--- PASS: Test_getCatalog (0.00s)
    --- PASS: Test_getCatalog/Default (0.00s)
    --- PASS: Test_getCatalog/SetCatalog (0.00s)
=== RUN   Test_getTimeout
=== RUN   Test_getTimeout/Default
=== RUN   Test_getTimeout/SetTimeout
--- PASS: Test_getTimeout (0.00s)
    --- PASS: Test_getTimeout/Default (0.00s)
    --- PASS: Test_getTimeout/SetTimeout (0.00s)
=== RUN   TestQuery
    db_test.go:111: resultMode: 0
    db_test.go:111: resultMode: 1
    db_test.go:111: resultMode: 2
--- PASS: TestQuery (39.22s)
=== RUN   TestPrepare
=== RUN   TestPrepare/ResultMode:0/NoInput
=== RUN   TestPrepare/ResultMode:0/IntType
=== RUN   TestPrepare/ResultMode:0/StringType
=== RUN   TestPrepare/ResultMode:0/FloatType
=== RUN   TestPrepare/ResultMode:0/DoubleType
=== RUN   TestPrepare/ResultMode:1/NoInput
=== RUN   TestPrepare/ResultMode:1/IntType
=== RUN   TestPrepare/ResultMode:1/StringType
=== RUN   TestPrepare/ResultMode:1/FloatType
=== RUN   TestPrepare/ResultMode:1/DoubleType
=== RUN   TestPrepare/ResultMode:2/NoInput
=== RUN   TestPrepare/ResultMode:2/IntType
=== RUN   TestPrepare/ResultMode:2/StringType
=== RUN   TestPrepare/ResultMode:2/FloatType
=== RUN   TestPrepare/ResultMode:2/DoubleType
--- PASS: TestPrepare (198.99s)
    --- PASS: TestPrepare/ResultMode:0/NoInput (6.68s)
    --- PASS: TestPrepare/ResultMode:0/IntType (11.94s)
    --- PASS: TestPrepare/ResultMode:0/StringType (12.02s)
    --- PASS: TestPrepare/ResultMode:0/FloatType (6.72s)
    --- PASS: TestPrepare/ResultMode:0/DoubleType (6.76s)
    --- PASS: TestPrepare/ResultMode:1/NoInput (12.32s)
    --- PASS: TestPrepare/ResultMode:1/IntType (7.09s)
    --- PASS: TestPrepare/ResultMode:1/StringType (12.18s)
    --- PASS: TestPrepare/ResultMode:1/FloatType (7.11s)
    --- PASS: TestPrepare/ResultMode:1/DoubleType (12.33s)
    --- PASS: TestPrepare/ResultMode:2/NoInput (18.29s)
    --- PASS: TestPrepare/ResultMode:2/IntType (18.28s)
    --- PASS: TestPrepare/ResultMode:2/StringType (18.38s)
    --- PASS: TestPrepare/ResultMode:2/FloatType (18.14s)
    --- PASS: TestPrepare/ResultMode:2/DoubleType (18.24s)
=== RUN   TestQueryForUsingWorkGroup
=== RUN   TestQueryForUsingWorkGroup/ResultMode:0
=== RUN   TestQueryForUsingWorkGroup/ResultMode:1
=== RUN   TestQueryForUsingWorkGroup/ResultMode:2
--- PASS: TestQueryForUsingWorkGroup (60.91s)
    --- PASS: TestQueryForUsingWorkGroup/ResultMode:0 (17.84s)
    --- PASS: TestQueryForUsingWorkGroup/ResultMode:1 (18.55s)
    --- PASS: TestQueryForUsingWorkGroup/ResultMode:2 (24.49s)
=== RUN   TestOpen
--- PASS: TestOpen (36.65s)
=== RUN   TestDDLQuery
--- PASS: TestDDLQuery (17.92s)
=== RUN   TestRows_Next
--- PASS: TestRows_Next (0.00s)
=== RUN   Test_getRecordsForDL
=== RUN   Test_getRecordsForDL/test
--- PASS: Test_getRecordsForDL (0.00s)
    --- PASS: Test_getRecordsForDL/test (0.00s)
PASS
ok  github.com/speee/go-athena 353.701s
```

## Ref