### PR TITLE
Specify catalog when executing query

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -182,6 +182,7 @@ func (c *conn) startQuery(ctx context.Context, query string) (string, error) {
 		QueryString: aws.String(query),
 		QueryExecutionContext: &types.QueryExecutionContext{
 			Database: aws.String(c.db),
+			Catalog:  aws.String(c.catalog),
 		},
 		ResultConfiguration: &types.ResultConfiguration{
 			OutputLocation: aws.String(c.OutputLocation),


### PR DESCRIPTION
## What

Fix catalog support in Athena query execution.

## Why

The driver previously had catalog support in the connection struct and context functions, but it wasn't being passed to the actual Athena query execution. This meant that even when users set a catalog via `SetCatalog()` or connection parameters, the catalog wasn't being used in the `QueryExecutionContext`, causing queries to run against the wrong catalog.

## How

Added the missing `Catalog: aws.String(c.catalog)` field to the `QueryExecutionContext` in the `startQuery()` function. The catalog infrastructure was already in place - it just wasn't being passed to the Athena API call.

## Ref